### PR TITLE
Remove peerDependencies, doesn't work like it should

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
     "@babel/core": "^7.4.5",
     "jest": "^23.6.0"
   },
-  "peerDependencies": {
-    "babel-core": "6.x || ^7.0.0-bridge.0"
-  },
   "scripts": {
     "test": "jest"
   }


### PR DESCRIPTION
warning " > babel-plugin-transform-minify-gql-template-literals@1.1.0" has unmet peer dependency "babel-core@6.x || ^7.0.0-bridge.0"